### PR TITLE
Fix Hono link typo

### DIFF
--- a/website/docs/basics/server.md
+++ b/website/docs/basics/server.md
@@ -2,7 +2,7 @@
 
 > Is it 🔥🔥🔥? It's gotta be Hono then!
 
-Reejs Server is primarily powe**ree**dby [Hono](httpss://hono.dev) and boasts its "_blazingly_" (Hi Jeff from Fireship.io!!!) fast performance on
+Reejs Server is primarily powe**ree**dby [Hono](https://hono.dev) and boasts its "_blazingly_" (Hi Jeff from Fireship.io!!!) fast performance on
 top of portability to other restricted runtimes as we are **ree**ally [living on the Edge!](https://youtu.be/8;Ugdf-zkQM) 🤣
 
 Jokes aside, consider Hono - _(炎 in Japanese)_ a contender to the likes of [Express](https://expressjs.com) and [Fastify](https://fastify.io) and is **ree**ady for the next


### PR DESCRIPTION
There was a typo in the url leading to the hono website